### PR TITLE
Exclude overclocking tier 0 modules (Tiberium compatability fix)

### DIFF
--- a/prototypes/cubeine-module-boost.lua
+++ b/prototypes/cubeine-module-boost.lua
@@ -352,5 +352,7 @@ for name, module in pairs(allmodules) do
 end
 
 for _, module in ipairs(modules) do
-    add_overclocking(module)
+    if module.tier > 0 then
+        add_overclocking(module)
+    end
 end


### PR DESCRIPTION
Tiberium has internal only modules defined as tier 0, I'm also making the assumption here that any negative tier modules should probably also be ignored should anyone decide to define some.